### PR TITLE
fix link to opencellid license

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project implements a cell-tower based lookup for your current location.
 It ships a binary cell database extracted from opencellid and thus licensed
 under the CC-BY-SA license. Review the following content for details:
 - res/assets/towers.bcs.xz (the data, xz compressed)
-- https://creativecommons.org/licenses/by-sa/3.0/ (the license)
-- http://wiki.opencellid.org/wiki/Licensing (the license statement of the source)
+- https://creativecommons.org/licenses/by-sa/4.0/ (the license)
+- https://wiki.opencellid.org/wiki/Licensing%3A (the license statement of the source)
 
 This "NetworkLocationProvider" works without network connectivity and will
 never post your data anywhere. You are thus encouraged to help opencellids


### PR DESCRIPTION
Their license page requires a trailing colon, and they've upgraded to CC-BA-SA-4.0, which is actually an approved free software license, while the 3.0 is not.